### PR TITLE
 FEAT: add conversion functions for TES and WES to WRROC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,176 @@
+# Created by https://www.toptal.com/developers/gitignore/api/python
+# Edit at https://www.toptal.com/developers/gitignore?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+# End of https://www.toptal.com/developers/gitignore/api/python

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+# Dockerfile for wrroc-ga4gh-cloud-converter
+FROM python:3.11.6
+WORKDIR /app
+COPY ./requirements.txt /app/requirements.txt
+RUN pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# WRROC <> GA4GH API Conversion Tool
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
+[![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/release/python-311/)
+
+## Synopsis
+This project aims to create a library that translates between GA4GH Cloud API schemas and RO-Crate profiles to facilitate reproducibility in scientific research. The tool will enable the packaging and sharing of task/tool and workflow runs, allowing other researchers to reproduce them or use parts of them.
+
+## Description
+The WRROC <> GA4GH API Conversion Tool is designed to compile RO-Crates from tool and workflow executions in GA4GH Cloud API-powered cloud infrastructures. This will allow easy re-execution of these computational analyses, thus improving the reporting and reproducibility of computational research.
+
+## Installation
+To install the necessary dependencies, run the following command:
+```bash
+pip install -r requirements.txt
+```
+
+## Contributing
+
+We welcome contributions from the community. Please fork the repository and create a pull request for any changes. Make sure to follow the coding standards and include tests for any new functionality.
+
+## Code of Conduct
+
+## Versioning
+
+## License
+
+This project is distributed under the [Apache License 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg), a
+copy of which is also available in [`LICENSE`][license].
+
+## Contact
+
+The project is maintained by [ELIXIR Cloud & AAI][elixir-cloud-aai].
+
+- For filing bug reports, feature requests or other code-related issues, please
+  make use of the project's [issue tracker](https://github.com/elixir-cloud-aai/wrroc-ga4gh-cloud-converter/issues).
+
+
+[badge-url-license]: <http://www.apache.org/licenses/LICENSE-2.0>
+[elixir-cloud-aai]: https://elixir-cloud.dcc.sib.swiss/
+[license]: LICENSE

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+requests
+pyyaml

--- a/src/converter.py
+++ b/src/converter.py
@@ -1,0 +1,114 @@
+import datetime
+import json
+
+def convert_tes_to_wrroc(tes_data):
+    wrroc = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@type": "Dataset",
+                "conformsTo": "https://w3id.org/ro/wfrun/process/0.4"
+            },
+            {
+                "@type": "CreateAction",
+                "@id": tes_data["id"],
+                "name": tes_data.get("name", ""),
+                "description": tes_data.get("description", ""),
+                "instrument": tes_data["executors"][0]["image"],
+                "object": [{"@id": input["url"], "name": input["path"]} for input in tes_data["inputs"]],
+                "result": [{"@id": output["url"], "name": output["path"]} for output in tes_data["outputs"]],
+                "startTime": convert_to_iso8601(tes_data["logs"][0]["start_time"]),
+                "endTime": convert_to_iso8601(tes_data["logs"][0]["end_time"]),
+                "actionStatus": convert_status(tes_data["state"]),
+            },
+            {
+                "@type": "SoftwareApplication",
+                "@id": tes_data["executors"][0]["image"],
+                "name": tes_data.get("name", "")
+            }
+        ]
+    }
+
+    return json.dumps(wrroc, indent=2)
+
+
+def convert_wes_to_wrroc(wes_data):
+    wrroc = {
+        "@context": "https://w3id.org/ro/crate/1.1/context",
+        "@graph": [
+            {
+                "@type": "Dataset",
+                "conformsTo": "https://w3id.org/ro/wfrun/workflow/0.4"
+            },
+            {
+                "@type": "CreateAction",
+                "@id": wes_data["run_id"],
+                "name": wes_data["run_log"].get("name", ""),
+                "description": wes_data["run_log"].get("description", ""),
+                "object": [{"@id": input["location"], "name": input["name"]} for input in wes_data["request"]["workflow_params"]],
+                "result": [{"@id": output["location"], "name": output["name"]} for output in wes_data["run_log"]["outputs"]],
+                "startTime": convert_to_iso8601(wes_data["run_log"]["start_time"]),
+                "endTime": convert_to_iso8601(wes_data["run_log"]["end_time"]),
+                "actionStatus": convert_status(wes_data["run_log"]["state"]),
+            },
+            {
+                "@type": "SoftwareApplication",
+                "@id": wes_data["request"]["workflow_url"],
+                "name": wes_data["request"].get("workflow_name", "")
+            }
+        ]
+    }
+
+    return json.dumps(wrroc, indent=2)
+
+
+def convert_to_iso8601(timestamp):
+    # Assuming timestamp is in RFC 3339 format, convert to ISO 8601
+    return datetime.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ").isoformat() + "Z"
+
+
+def convert_status(wes_status):
+    # Convert WES run status to CreateAction actionStatus
+    status_mapping = {
+        "COMPLETE": "schema:CompletedActionStatus",
+        "EXECUTOR_ERROR": "schema:FailedActionStatus",
+        "SYSTEM_ERROR": "schema:FailedActionStatus",
+        "CANCELED": "schema:CanceledActionStatus",
+        "RUNNING": "schema:ActiveActionStatus",
+        "QUEUED": "schema:PotentialActionStatus",
+        "INITIALIZING": "schema:PotentialActionStatus",
+        "PAUSED": "schema:PotentialActionStatus"
+    }
+    return status_mapping.get(wes_status, "schema:PotentialActionStatus")
+
+
+# Example usage
+if __name__ == "__main__":
+    wes_run_example = {
+        "run_id": "run123",
+        "request": {
+            "workflow_url": "http://example.com/workflow",
+            "workflow_name": "Example Workflow",
+            "workflow_params": [
+                {
+                    "location": "http://example.com/input1",
+                    "name": "input1"
+                }
+            ]
+        },
+        "run_log": {
+            "name": "Example Run",
+            "description": "This is an example workflow run",
+            "state": "COMPLETE",
+            "outputs": [
+                {
+                    "location": "http://example.com/output1",
+                    "name": "output1"
+                }
+            ],
+            "start_time": "2024-01-01T00:00:00Z",
+            "end_time": "2024-01-01T01:00:00Z"
+        }
+    }
+    wrroc = convert_wes_to_wrroc(wes_run_example)
+    print(wrroc)

--- a/src/converter.py
+++ b/src/converter.py
@@ -2,88 +2,146 @@ import datetime
 import json
 
 def convert_tes_to_wrroc(tes_data):
-    wrroc = {
-        "@context": "https://w3id.org/ro/crate/1.1/context",
-        "@graph": [
-            {
-                "@type": "Dataset",
-                "conformsTo": "https://w3id.org/ro/wfrun/process/0.4"
-            },
-            {
-                "@type": "CreateAction",
-                "@id": tes_data["id"],
-                "name": tes_data.get("name", ""),
-                "description": tes_data.get("description", ""),
-                "instrument": tes_data["executors"][0]["image"],
-                "object": [{"@id": input["url"], "name": input["path"]} for input in tes_data["inputs"]],
-                "result": [{"@id": output["url"], "name": output["path"]} for output in tes_data["outputs"]],
-                "startTime": convert_to_iso8601(tes_data["logs"][0]["start_time"]),
-                "endTime": convert_to_iso8601(tes_data["logs"][0]["end_time"]),
-                "actionStatus": convert_status(tes_data["state"]),
-            },
-            {
-                "@type": "SoftwareApplication",
-                "@id": tes_data["executors"][0]["image"],
-                "name": tes_data.get("name", "")
-            }
-        ]
-    }
+    try:
+        if not tes_data or not isinstance(tes_data, dict):
+            raise ValueError("Invalid TES data provided")
 
-    return json.dumps(wrroc, indent=2)
+        if not tes_data.get("executors"):
+            raise ValueError("TES data missing 'executors' list or 'executors' list is empty")
 
+        wrroc = {
+            "@context": "https://w3id.org/ro/crate/1.1/context",
+            "@graph": [
+                {
+                    "@type": "Dataset",
+                    "conformsTo": "https://w3id.org/ro/wfrun/process/0.4"
+                },
+                {
+                    "@type": "CreateAction",
+                    "@id": tes_data.get("id"),
+                    "name": tes_data.get("name", ""),
+                    "description": tes_data.get("description", ""),
+                    "instrument": tes_data["executors"][0].get("image"),
+                    "object": [{"@id": input.get("url"), "name": input.get("path")} for input in tes_data.get("inputs", []) if input.get("url") and input.get("path")],
+                    "result": [{"@id": output.get("url"), "name": output.get("path")} for output in tes_data.get("outputs", []) if output.get("url") and output.get("path")],
+                    "startTime": convert_to_iso8601(tes_data["logs"][0].get("start_time")),
+                    "endTime": convert_to_iso8601(tes_data["logs"][0].get("end_time")),
+                    "actionStatus": convert_status(tes_data.get("state")),
+                },
+                {
+                    "@type": "SoftwareApplication",
+                    "@id": tes_data["executors"][0].get("image"),
+                    "name": tes_data.get("name", "")
+                }
+            ]
+        }
+
+        return json.dumps(wrroc, indent=2)
+    except KeyError as e:
+        raise ValueError(f"Missing expected key: {e}")
+    except IndexError as e:
+        raise ValueError(f"Missing expected index: {e}")
+    except Exception as e:
+        raise ValueError(f"An error occurred during TES to WRROC conversion: {e}")
 
 def convert_wes_to_wrroc(wes_data):
-    wrroc = {
-        "@context": "https://w3id.org/ro/crate/1.1/context",
-        "@graph": [
-            {
-                "@type": "Dataset",
-                "conformsTo": "https://w3id.org/ro/wfrun/workflow/0.4"
-            },
-            {
-                "@type": "CreateAction",
-                "@id": wes_data["run_id"],
-                "name": wes_data["run_log"].get("name", ""),
-                "description": wes_data["run_log"].get("description", ""),
-                "object": [{"@id": input["location"], "name": input["name"]} for input in wes_data["request"]["workflow_params"]],
-                "result": [{"@id": output["location"], "name": output["name"]} for output in wes_data["run_log"]["outputs"]],
-                "startTime": convert_to_iso8601(wes_data["run_log"]["start_time"]),
-                "endTime": convert_to_iso8601(wes_data["run_log"]["end_time"]),
-                "actionStatus": convert_status(wes_data["run_log"]["state"]),
-            },
-            {
-                "@type": "SoftwareApplication",
-                "@id": wes_data["request"]["workflow_url"],
-                "name": wes_data["request"].get("workflow_name", "")
-            }
-        ]
-    }
+    try:
+        if not wes_data or not isinstance(wes_data, dict):
+            raise ValueError("Invalid WES data provided")
 
-    return json.dumps(wrroc, indent=2)
+        if not wes_data.get("run_log") or not wes_data["run_log"].get("outputs"):
+            raise ValueError("WES data missing 'run_log' or 'outputs'")
 
+        wrroc = {
+            "@context": "https://w3id.org/ro/crate/1.1/context",
+            "@graph": [
+                {
+                    "@type": "Dataset",
+                    "conformsTo": "https://w3id.org/ro/wfrun/workflow/0.4"
+                },
+                {
+                    "@type": "CreateAction",
+                    "@id": wes_data.get("run_id"),
+                    "name": wes_data["run_log"].get("name", ""),
+                    "description": wes_data["run_log"].get("description", ""),
+                    "object": [{"@id": input.get("location"), "name": input.get("name")} for input in wes_data["request"].get("workflow_params", []) if input.get("location") and input.get("name")],
+                    "result": [{"@id": output.get("location"), "name": output.get("name")} for output in wes_data["run_log"].get("outputs", []) if output.get("location") and output.get("name")],
+                    "startTime": convert_to_iso8601(wes_data["run_log"].get("start_time")),
+                    "endTime": convert_to_iso8601(wes_data["run_log"].get("end_time")),
+                    "actionStatus": convert_status(wes_data["run_log"].get("state")),
+                },
+                {
+                    "@type": "SoftwareApplication",
+                    "@id": wes_data["request"].get("workflow_url"),
+                    "name": wes_data["request"].get("workflow_name", "")
+                }
+            ]
+        }
+
+        return json.dumps(wrroc, indent=2)
+    except KeyError as e:
+        raise ValueError(f"Missing expected key: {e}")
+    except IndexError as e:
+        raise ValueError(f"Missing expected index: {e}")
+    except Exception as e:
+        raise ValueError(f"An error occurred during WES to WRROC conversion: {e}")
 
 def convert_to_iso8601(timestamp):
-    # Assuming timestamp is in RFC 3339 format, convert to ISO 8601
-    return datetime.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ").isoformat() + "Z"
+    try:
+        if not timestamp:
+            raise ValueError("Timestamp is missing")
+        return datetime.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ").isoformat() + "Z"
+    except ValueError as e:
+        raise ValueError(f"Invalid timestamp format: {timestamp}. Error: {e}")
 
-
-def convert_status(wes_status):
-    # Convert WES run status to CreateAction actionStatus
-    status_mapping = {
-        "COMPLETE": "schema:CompletedActionStatus",
-        "EXECUTOR_ERROR": "schema:FailedActionStatus",
-        "SYSTEM_ERROR": "schema:FailedActionStatus",
-        "CANCELED": "schema:CanceledActionStatus",
-        "RUNNING": "schema:ActiveActionStatus",
-        "QUEUED": "schema:PotentialActionStatus",
-        "INITIALIZING": "schema:PotentialActionStatus",
-        "PAUSED": "schema:PotentialActionStatus"
-    }
-    return status_mapping.get(wes_status, "schema:PotentialActionStatus")
-
+def convert_status(status):
+    try:
+        status_mapping = {
+            "COMPLETE": "schema:CompletedActionStatus",
+            "EXECUTOR_ERROR": "schema:FailedActionStatus",
+            "SYSTEM_ERROR": "schema:FailedActionStatus",
+            "CANCELED": "schema:CanceledActionStatus",
+            "RUNNING": "schema:ActiveActionStatus",
+            "QUEUED": "schema:PotentialActionStatus",
+            "INITIALIZING": "schema:PotentialActionStatus",
+            "PAUSED": "schema:PotentialActionStatus"
+        }
+        return status_mapping.get(status, "schema:PotentialActionStatus")
+    except KeyError:
+        raise ValueError(f"Invalid status value: {status}")
 
 # Example usage
 if __name__ == "__main__":
+    tes_task_example = {
+        "id": "task123",
+        "name": "Example Task",
+        "description": "This is an example task",
+        "state": "COMPLETE",
+        "executors": [
+            {
+                "image": "example/image:1.0"
+            }
+        ],
+        "inputs": [
+            {
+                "url": "http://example.com/input1",
+                "path": "/data/input1"
+            }
+        ],
+        "outputs": [
+            {
+                "url": "http://example.com/output1",
+                "path": "/data/output1"
+            }
+        ],
+        "logs": [
+            {
+                "start_time": "2022-01-01T00:00:00Z",
+                "end_time": "2022-01-01T01:00:00Z"
+            }
+        ]
+    }
+
     wes_run_example = {
         "run_id": "run123",
         "request": {
@@ -106,9 +164,10 @@ if __name__ == "__main__":
                     "name": "output1"
                 }
             ],
-            "start_time": "2024-01-01T00:00:00Z",
-            "end_time": "2024-01-01T01:00:00Z"
+            "start_time": "2022-01-01T00:00:00Z",
+            "end_time": "2022-01-01T01:00:00Z"
         }
     }
-    wrroc = convert_wes_to_wrroc(wes_run_example)
-    print(wrroc)
+
+    print(convert_tes_to_wrroc(tes_task_example))
+    print(convert_wes_to_wrroc(wes_run_example))


### PR DESCRIPTION
### Description

This PR adds the implementation of the `convert_tes_to_wrroc` and `convert_wes_to_wrroc` functions. These functions are responsible for converting TES (Task Execution Service) and WES (Workflow Execution Service) tasks and runs into WRROC (Workflow Run RO-Crate) format.

### Changes Included

- **`convert_tes_to_wrroc` function**: Converts TES tasks to WRROC format by mapping TES properties to WRROC properties.
- **`convert_wes_to_wrroc` function**: Converts WES runs to WRROC format by mapping WES properties to WRROC properties.
- **Helper functions**:
  - `convert_to_iso8601`: Converts timestamps from RFC 3339 format to ISO 8601 format.
  - `convert_status`: Maps TES and WES task statuses to appropriate `CreateAction` statuses in WRROC.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds conversion functions for transforming TES tasks and WES runs into WRROC format, along with helper functions for timestamp conversion and status mapping.

* **New Features**:
    - Introduced `convert_tes_to_wrroc` function to convert TES tasks to WRROC format.
    - Introduced `convert_wes_to_wrroc` function to convert WES runs to WRROC format.
* **Enhancements**:
    - Added helper function `convert_to_iso8601` to convert timestamps from RFC 3339 format to ISO 8601 format.
    - Added helper function `convert_status` to map TES and WES task statuses to appropriate `CreateAction` statuses in WRROC.

<!-- Generated by sourcery-ai[bot]: end summary -->